### PR TITLE
Fix typos and broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,9 @@
 
 # Contribution Guidelines
-The contribution guidelines in this document pertain to contributing to this mq-config repository.
+
+This document is intended to be a living summary of conventions & best practices for development within IBM® MQ Plug-in for Zowe CLI.
+
+## Primary Contribution Guidelines
 
 We provide specific guidelines for developing Zowe MQ plug-in in the [Zowe CLI GitHub repository](https://github.com/zowe/mq-config). The following information is critical to working with the code, running/writing/maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates with Zowe CLI properly:
 
@@ -12,3 +15,9 @@ We provide specific guidelines for developing Zowe MQ plug-in in the [Zowe CLI G
 | Guidelines for running tests on the plug-ins that you build for Zowe CLI | [Plug-in Testing Guidelines](https://github.com/zowe/zowe-cli/blob/master/docs/PluginTESTINGGuidelines.md) |
 | Documentation that describes the features of the Imperative CLI Framework | [About Imperative CLI Framework](https://github.com/zowe/imperative/wiki) |
 Versioning conventions for Zowe CLI and Plug-ins| [Versioning Guidelines](https://github.com/zowe/zowe-cli/blob/master/docs/MaintainerVersioning.md) |
+
+## Contribution Guidelines Specific to the IBM MQ Plug-in for Zowe CLI
+
+The following guidelines apply specifically to the IBM MQ Plug-in for Zowe CLI:
+
+-   None at this time.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli-ims-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli-mq-plugin)
 
-The IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. With MQSC commands, you can perform administration tasks, such as defining, altering, and deleting local queue objects. For more information MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
+The IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. With MQSC commands, you can perform administration tasks, such as defining, altering, and deleting local queue objects. For information MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
 
 ## Understanding how the plug-in works
 
@@ -19,7 +19,7 @@ Before you install the plug-in, complete the following prerequisites:
 
 -   Ensure that [IBM® MQ™ v9.1.0](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.sce.doc/q121910_.htm) or later is installed and running in your mainframe environment.
 
--   Zowe installation with MQ. For more insformation, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/)
+-   Zowe installation with MQ. For more insformation, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/).
 
 ## Installing the plug-in
 
@@ -27,11 +27,11 @@ Use one of the following methods to install the plug-in:
 
 -   Install the plug-in from an online registry or a local package.
 
-    Use this method when you simply want to install the plug-in to Zowe CLI and start using it. For more information, see [Installing plug-ins](https://zowe.github.io/docs-site/latest/user-guide/cli-installplugins.html) on the [Zowe Docs](https://zowe.github.io/docs-site/latest/) website.
+    Use the online registry/local package method when you simply want to install the plug-in to Zowe CLI and start using it. For more information, see [Installing plug-ins](https://zowe.github.io/docs-site/latest/user-guide/cli-installplugins.html) on the [Zowe Docs](https://zowe.github.io/docs-site/latest/) website.
 
 -   Build the plug-in from source and install it into your Zowe CLI implementation.
 
-    Use this method when you want to install tha plug-in to Zowe CLI using the most current binaries and modify the behavior of the plug-in. For example, you want to create a new command and use the plug-in with the command that you created. For more information, see [Building the plug-in from source](#building-the-plug-in-from-source).
+    Use the build from source method when you want to install tha plug-in to Zowe CLI using the most current binaries and modify the behavior of the plug-in. For example, you want to create a new command and use the plug-in with the command that you created. For more information, see [Building the plug-in from source](#building-the-plug-in-from-source).
 
 ## Building the plug-in from source
 
@@ -104,14 +104,14 @@ zowe profiles create mq-profile -h
 
 ## Run Tests
 
-The IBM MQ Plug-in for Zowe CLI uses the following tests:
+You can perform the follwing types of tests:
 - unit
 - integration
 - system
 
 Before running the system and integration tests, you must have a server connection to run against. For more information, see [Prerequisites](#prerequisites).
 
-To define  access credentials to the server, copy the file named `__tests__/__resources__/properties/example_properties.yaml` and create a file named `__tests__/__resources__/properties/custom_properties.yaml`.
+To define  access credentials to the server, copy the  file named `.../__tests__/__resources__/properties/example_properties.yaml` and create a file named `.../__tests__/__resources__/properties/custom_properties.yaml`.
 
 **Note:** Information about how to customize the `custom_properties.yaml` file is provided in the yaml file itself.
 
@@ -125,14 +125,14 @@ Any failures potentially indicate an issue with the set-up of the Rest API or co
 ## Uninstall the plug-in
 
 **Follow these steps:**
+
 1.  Issue the following command:
 
     ```
     zowe plugins uninstall @zowe/mq-for-zowe-cli
     ```
     
-After the uninstallation process completes successfully, the product no longer contains the plug-in. 
-
+After the uninstallation process completes successfully, the product no longer contains the plug-in.
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli-ims-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli-mq-plugin)
 
-The IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. With MQSC commands you can perform administration tasks, such as defining, altering, and deleting local queue objects. For more infornation MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
+The IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. With MQSC commands, you can perform administration tasks, such as defining, altering, and deleting local queue objects. For more information MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
+
+## Understanding how the plug-in works
+
+-   The plug-in defines an MQ profile to manage the connection information, which is required to access the MQ API.
+-   It implements a local API to interface with the relevant API on the server.
+-   The plug-in creates a wrapping CLI around the local API to provide the command line function.
 
 ## Prerequisites
 
@@ -14,12 +20,6 @@ Before you install the plug-in, complete the following prerequisites:
 -   Ensure that [IBM® MQ™ v9.1.0](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.sce.doc/q121910_.htm) or later is installed and running in your mainframe environment.
 
 -   Zowe installation with MQ. For more insformation, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/)
-
-## Understanding how the plug-in works
-
--   The plug-in defines an MQ profile to manage the connection information that is required to access the MQ API.
--   It implements a local API to interface with the relevant API on the server.
--   The plug-in creates a wrapping CLI around the local API to provide the command line function.
 
 ## Installing the plug-in
 
@@ -146,4 +146,4 @@ To learn about how to work with this sample plug-in, build new commands, or buil
 
 For information about contributing to the plug-in, see the Zowe CLI [contribution guidelines](CONTRIBUTING.md). The guidelines contain standards and conventions for developing plug-ins for Zowe CLI.
 
-The guidelines contain critical information about working with the code, running, writing, maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates properly with Zowe CLI.
+The guidelines contain critical information about working with the code. This includes information about, running, writing, maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates properly with Zowe CLI.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Use one of the following methods to install the plug-in:
 
 The validation process helps to ensure the following conditions:
 -   The installation process completed successfully.
--   The plug-in does ***not*** contain commands, options, and arguments that conflict (possess the same names) as the other plug-ins that are installed in your Zowe CLI installation.
+-   The plug-in does ***not*** contain commands, options, and arguments that conflict (possess the same names) with other plug-ins that are installed in your Zowe CLI installation.
 
 **Follow these steps:**
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,6 @@ To learn about how to work with the sample plug-in, build new commands, or build
 
 ## Contributing to the plug-in
 
-For information about contributing to the plug-in, see the Zowe CLI [contribution guidelines](CONTRIBUTING.md). The guidelines contain standards and conventions for developing plug-ins for Zowe CLI.
+For information about contributing to the plug-in, see the Zowe CLI [Contribution Guidelines](CONTRIBUTING.md). The guidelines contain standards and conventions for developing plug-ins for Zowe CLI.
 
 The guidelines contain critical information about working with the code. This includes information about, running, writing, maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates properly with Zowe CLI.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Use one of the following methods to install the plug-in:
 
 **Tip:** After the installation process completes, it validates that the plug-in was installed correct and the names of its commands, options, and arguments do not conflict with that of the other plug-ins that you installed into your Zowe CLi implimentation.
 
-When the validation process is successful, the following messaage displays:
+When the validation process is successful, the following message displays:
 
 ```
 Validation results for plugin 'mq':

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager.
 
 Before you install and use the plug-in:
 
+<!-- TODO When @latest branch of Zowe docs-site exists, we should give users the option to go and read about/install the @latest or the @lts-incremental versions of this plug-in. We can also explain which branches in the repo correspond to which CLI version. -->
+
 -   Install Zowe CLI on your computer.
 
     **Note:** For more information, see [Installing Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html).

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli-ims-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli-mq-plugin)
 
-This repository contains a IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. MQSC commands let you perform administration tasks, such as defining, altering, and deleting local queue objects. For more infornation MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
+The IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. MQSC commands let you perform administration tasks, such as defining, altering, and deleting local queue objects. For more infornation MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
 
-## Contributing to this plug-in 
+## Contributing to the plug-in 
 For information about contributing to the plug-in, see the Zowe CLI [contribution guidelines](CONTRIBUTING.md), which contains standards and conventions for developing plug-ins for Zowe CLI.
 
 The guidelines contain critical information about working with the code, running, writing, maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates properly with Zowe CLI.
 
 ## Prerequisites
 Before you install the plug-in, complete the following prerequisites:
-* Install Zowe CLI on your PC.
-   **Note:** For more information, see [Installing Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html).
+-   Install Zowe CLI on your computer.
+
+    **Note:** For more information, see [Installing Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html).
 
 * Ensure that [IBM® MQ™ v9.1.0](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.sce.doc/q121910_.htm) or later is installed and running in your mainframe environment.
 
@@ -95,7 +96,6 @@ You can create an `mq` user profile to avoid typing your connection details on e
 1.  Create an `mq` profile: 
     ```
     zowe profiles create mq-profile <profileName> --host <hostname> --port <portnumber> --user <username> --password <password> --rejectUnauthorized false
-
     ```
     The result of the command displays as a success or failure message. You can use your profile when you issue commands in the mq command group.
 
@@ -106,7 +106,11 @@ zowe profiles create mq-profile -h
 ```
 
 ## Run Tests
-The IBM MQ Plug-in for Zowe CLI uses three sets of tests; unit, integration and system.
+
+The IBM MQ Plug-in for Zowe CLI uses the following tests:
+- unit
+- integration
+- system
 
 Before running the integration and system tests it is necessary to have a server connection to run against as described in the [Prerequisites](#prerequisites) section.
 
@@ -123,17 +127,19 @@ Any failures potentially indicate an issue with the set-up of the Rest API or co
 ## Uninstall the plug-in
 
 **Follow these steps:**
-1.  To uninstall the plug-in from a base application, issue the following command:
+1.  Issue the following command:
+
     ```
     zowe plugins uninstall @zowe/mq-for-zowe-cli
     ```
+    
 After the uninstallation process completes successfully, the product no longer contains the plug-in. 
 
 
 ### Tutorials
+
 To learn about how to work with this sample plug-in, build new commands, or build a new plug-in for Zowe CLI, see [Develop for Zowe CLI](https://zowe.github.io/docs-site/latest/extend/extend-cli/cli-devTutorials.html).
 
 ### Imperative CLI Framework Documentation
-[Imperative CLI Framework](https://github.com/zowe/imperative/wiki) documentation is a key source of information to learn about the features of Imperative CLI Framework (the code framework that you use to build plug-ins for Zowe CLI). Refer to these documents during development. 
 
-
+[Imperative CLI Framework](https://github.com/zowe/imperative/wiki) documentation is a key source of information to learn about the features of Imperative CLI Framework (the code framework that you use to build plug-ins for Zowe CLI). Refer to the documentation as you develop your plug-in.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Before you install and use the plug-in:
 
 -   Ensure that [IBM® MQ™ v9.1.0](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.sce.doc/q121910_.htm) or later is installed and running in your mainframe environment.
 
--   Zowe installation with MQ. For more information, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/).
+-   Expose the MQ API the API Mediation Layer (API ML), or, connect the plug-in directly to the MQ API. For more information, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/) and [Configuring the mqweb server](https://www.ibm.com/support/knowledgecenter/SSFKSJ_9.1.0/com.ibm.mq.con.doc/q019098_.htm).
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -2,29 +2,41 @@
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli-ims-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli-mq-plugin)
 
-This repository contains a IBM MQ Plug-in for Zowe CLI that enables users to issue MQSC commands to a queue manager. 
-MQSC commands enable you to perform administration tasks. For example, you can define, alter, or delete a local queue object. MQSC commands and their syntax are described in [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm) 
+This repository contains a IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. MQSC commands let you perform administration tasks, such as defining, altering, and deleting local queue objects. For more infornation MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
 
-## Contributing to this plugin 
-Please refer to the Zowe CLI [contribution guidelines](CONTRIBUTING.md) which contain standards and conventions for developing plug-ins for Zowe CLI. 
+## Contributing to this plug-in 
+For information about contributing to the plug-in, see the Zowe CLI [contribution guidelines](CONTRIBUTING.md), which contains standards and conventions for developing plug-ins for Zowe CLI.
 
-The guidelines contain critical information about working with the code, running/writing/maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates with Zowe CLI properly.
+The guidelines contain critical information about working with the code, running, writing, maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates properly with Zowe CLI.
 
-### Prerequisites
-Before you install the plug-in, the following prerequisites need to be met:
+## Prerequisites
+Before you install the plug-in, complete the following prerequisites:
 * Install Zowe CLI on your PC.
    **Note:** For more information, see [Installing Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html).
 
 * Ensure that [IBM® MQ™ v9.1.0](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.sce.doc/q121910_.htm) or later is installed and running in your mainframe environment.
 
-* Zowe installation with MQ. Please read this blog for more information: [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/)
+* Zowe installation with MQ. For more insformation, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/)
 
-## Structure of the MQ Plug-in
-- This plugin defines an MQ profile to manage the connection information required to access the MQ API
-- Implements a local API to interface with the relevant API on the server
-- Creates a wrapping CLI around the local API to provide the command line function
+## Understanding how the plug-in works
+- The plug-in defines an MQ profile to manage the connection information that is required to access the MQ API.
+- It implements a local API to interface with the relevant API on the server.
+- The plug-in creates a wrapping CLI around the local API to provide the command line function.
 
-## Build the Plug-in from Source
+## Installing the plug-in
+
+Use one of the following methods to install the plug-in:
+
+-   Install the plug-in from an online registry or a local package.
+
+    Use this method when you simply want to install the plug-in to Zowe CLI and start using it. For more information, see [Installing plug-ins](https://zowe.github.io/docs-site/latest/user-guide/cli-installplugins.html) on the [Zowe Docs](https://zowe.github.io/docs-site/latest/) website.
+
+-   Build the plug-in from source and install it into your Zowe CLI implementation.
+
+    Use this method when you want to install tha plug-in to Zowe CLI using the most current binaries and modify the behavior of the plug-in. For example, you want to create a new command and use the plug-in with the command that you created. For more information, see [Building the plug-in from source](#building-the-plug-in-from-source).
+
+## Building the plug-in from source
+
 **Follow these steps:**
 1. The first time that you clone the IBM MQ Plug-in for Zowe CLI from the GitHub repository, issue the following command against the local directory:
 
@@ -43,20 +55,29 @@ Before you install the plug-in, the following prerequisites need to be met:
 
     **Note:** When you update `package.json` to include new dependencies, or when you pull changes that affect `package.json`, issue the `npm update` command to download the dependencies.
 
-## Install the IBM MQ Plug-in for Zowe CLI
+3. Issue one of the following commands to install the plug-in:
+
+    ```
+    zowe plugins install <local path your cloned repo>
+    ```
+
+    Or:
+
+    ```
+    zowe plugins install .
+    ```
+
+## Validate the plug-in
+
+The validation process helps to ensure the following conditions:
+The installation process completed successfully.
+The plug-in does ***not*** contain commands, options, and arguement that conflict (possess the same names) as the other plug-ins that are installed in your Zowe CLI installation.
+
+**Note:** This is an optional task.
 
 **Follow these steps:**
 
-1.  [Meet the prerequisites](#prerequisites).
-
-2.  Install the plug-in:
-    ```
-    zowe plugins install @zowe/mq-for-zowe-cli
-    ``` 
-    
-    **Note**: The `latest` npm tag installs a version of the product that is intended for public consumption. You can use different npm tags to install other versions of the product. For example, you can install with the `@beta` tag to try new features that have not been fully validated. For more information about tag usage, see [NPM Tag Names](https://github.com/zowe/zowe-cli/blob/master/docs/MaintainerVersioning.md#npm-tag-names).
-    
-3.  (Optional) Verify the installation:
+1. Issue the following command:
     ```
     zowe plugins validate @zowe/mq-for-zowe-cli
     ```
@@ -66,8 +87,6 @@ Before you install the plug-in, the following prerequisites need to be met:
     Successfully validated.
     ``` 
     **Tip:** When an unsuccessful message displays, you can troubleshoot the installation by addressing the issues that the message describes. You can also review the information that is contained in the log file that is located in the directory where you installed Zowe CLI.  
-
-4.  [Create a user profile](#create-a-user-profile).
 
 ## Create a User Profile
 You can create an `mq` user profile to avoid typing your connection details on every command. An `mq` profile contains the host, port, username, and password for the MQ Rest API server of your choice. You can create multiple profiles and switch between them as needed.
@@ -95,13 +114,13 @@ Access credentials to this server is defined by copying the __tests__/__resource
 Instructions of how to update your new custom_properties.yaml are provided in the file itself.
 
  To run the unit tests simply type in the following:
-1. npm run test:unit
-2. npm run test:integration
-3. npm run test:system
+1. `npm run test:unit`
+2. `npm run test:integration`
+3. `npm run test:system`
 
 Any failures potentially indicate an issue with the set-up of the Rest API or configuration parameters passed in the custom_properties.yaml file
 
-## Uninstall the Plug-in
+## Uninstall the plug-in
 
 **Follow these steps:**
 1.  To uninstall the plug-in from a base application, issue the following command:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Use one of the following methods to install the plug-in:
 
     Use the build from source method when you want to install the plug-in to Zowe CLI using the most current binaries and modify the behavior of the plug-in. For example, you want to create a new command and use the plug-in with the command that you created.
     
-    For more information, see [Building the plug-in from source](#building-the-plug-in-from-source).
+    For more information, see [Building from source](#building-from-source).
 
 ## Building from source
 
@@ -82,7 +82,7 @@ Use one of the following methods to install the plug-in:
     zowe plugins install .
     ```
 
-**Tip:** After the installation process completes, it validates that the plug-in was installed correct and the names of its commands, options, and arguments do not conflict with that of the other plug-ins that you installed into your Zowe CLI implimentation.
+**Tip:** After the installation process completes, it validates that the plug-in was installed correct and the names of its commands, options, and arguments do not conflict with that of the other plug-ins that you installed into your Zowe CLI implementation.
 
 When the validation process is successful, the following message displays:
 
@@ -117,7 +117,7 @@ You can perform the following types of tests on the IBM MQ plug-in:
 - Integration
 - System
 
-**Note:** For detailed information about conventions and best practices for running tests against Zowe CLI plug-ins, see see [Zowe CLI Plug-in Testing Guidelines](https://github.com/zowe/zowe-cli/blob/master/docs/PluginTESTINGGuidelines.md).
+**Note:** For detailed information about conventions and best practices for running tests against Zowe CLI plug-ins, see [Zowe CLI Plug-in Testing Guidelines](https://github.com/zowe/zowe-cli/blob/master/docs/PluginTESTINGGuidelines.md).
 
 Before running the system and integration tests, you must have a server connection to run against. For more information, see [Software requirements](#software-requirements).
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
-# IBM® MQ Plug-in for Zowe CLI
+# IBM® MQ Plug-in for Zowe CLI  <!-- omit in toc -->
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli-ims-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli-mq-plugin)
 
 The IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. With MQSC commands, you can perform administration tasks, such as defining, altering, and deleting local queue objects. For information MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
 
-## Understanding how the plug-in works
+- [How the plug-in works](#how-the-plug-in-works)
+- [Software requirements](#software-requirements)
+- [Installing](#installing)
+- [Building from source](#building-from-source)
+- [Creating a user profile](#creating-a-user-profile)
+- [Running tests](#running-tests)
+- [Uninstalling](#uninstalling)
+- [Contributing](#contributing)
 
--   The plug-in defines an MQ profile to manage the connection information, which is required to access the MQ API.
--   It implements a local API to interface with the relevant API on the server.
--   The plug-in creates a wrapping CLI around the local API to provide the command line function.
+## How the plug-in works
 
-## Prerequisites
+- The plug-in defines an MQ profile to manage the connection information, which is required to access the MQ API.
+- It implements a local API to interface with the relevant API on the server.
+- The plug-in creates a wrapping CLI around the local API to provide the command-line function.
 
-Before you install the plug-in, complete the following prerequisites:
+## Software requirements
+
+Before you install and use the plug-in:
+
 -   Install Zowe CLI on your computer.
 
     **Note:** For more information, see [Installing Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html).
@@ -21,7 +31,7 @@ Before you install the plug-in, complete the following prerequisites:
 
 -   Zowe installation with MQ. For more information, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/).
 
-## Installing the plug-in
+## Installing
 
 Use one of the following methods to install the plug-in:
 
@@ -37,7 +47,7 @@ Use one of the following methods to install the plug-in:
     
     For more information, see [Building the plug-in from source](#building-the-plug-in-from-source).
 
-## Building the plug-in from source
+## Building from source
 
 **Follow these steps:**
 
@@ -46,7 +56,7 @@ Use one of the following methods to install the plug-in:
     ```
     npm install
     ```
-    The command installs the required IBM MQ Plug-in for Zowe CLI dependencies and several development tools. When necessary, you can run the task at any time to update the tools.
+    The command installs the required dependencies and several development tools. You can run the task at any time to update the tools as needed.
 
 2.  To build your code changes, issue the following command:
 
@@ -54,7 +64,7 @@ Use one of the following methods to install the plug-in:
     npm run build
     ```
 
-    The first time you build your code changes, you will be prompted for the location of the Imperative CLI Framework package, which is located in the `node_modules/@zowe` folder in the directory where Zowe CLI was installed.
+    The first time you build your code changes, you will be prompted for the location of the Imperative CLI Framework package, which is located in the `node_modules/@zowe` folder in the Zowe CLI home directory.
 
     **Note:** When you update `package.json` to include new dependencies, or when you pull changes that affect `package.json`, issue the `npm update` command to download the dependencies.
 
@@ -70,7 +80,7 @@ Use one of the following methods to install the plug-in:
     zowe plugins install .
     ```
 
-**Tip:** After the installation process completes, it validates that the plug-in was installed correct and the names of its commands, options, and arguments do not conflict with that of the other plug-ins that you installed into your Zowe CLi implimentation.
+**Tip:** After the installation process completes, it validates that the plug-in was installed correct and the names of its commands, options, and arguments do not conflict with that of the other plug-ins that you installed into your Zowe CLI implimentation.
 
 When the validation process is successful, the following message displays:
 
@@ -79,7 +89,7 @@ Validation results for plugin 'mq':
 Successfully validated.
 ```
 
-When an unsuccessful message displays, you can troubleshoot the installation by addressing the issues that the message describes. You can also review the information that is contained in the log file that is located in the directory where you installed Zowe CLI.
+When an unsuccessful message displays, you can troubleshoot the installation by addressing the issues that the message describes. You can also review the information that is contained in the log file that is located in the Zowe CLI home directory.
 
 ## Creating a user profile
 You can create an `mq` user profile to avoid typing your connection details on every command. An `mq` profile contains the host, port, username, and password for the MQ Rest API server of your choice. You can create multiple profiles and switch between them as needed.
@@ -107,7 +117,7 @@ You can perform the following types of tests on the IBM MQ plug-in:
 
 **Note:** For detailed information about conventions and best practices for running tests against Zowe CLI plug-ins, see see [Zowe CLI Plug-in Testing Guidelines](https://github.com/zowe/zowe-cli/blob/master/docs/PluginTESTINGGuidelines.md).
 
-Before running the system and integration tests, you must have a server connection to run against. For more information, see [Prerequisites](#prerequisites).
+Before running the system and integration tests, you must have a server connection to run against. For more information, see [Software requirements](#software-requirements).
 
 To define access credentials to the server, copy the file named `.../__tests__/__resources__/properties/example_properties.yaml` and create a file named `.../__tests__/__resources__/properties/custom_properties.yaml`.
 
@@ -120,7 +130,7 @@ Issue the following commands to run the tests:
 
 Any failures potentially indicate an issue with the set-up of the Rest API or configuration parameters that were passed in the `custom_properties.yaml` file.
 
-## Uninstalling the plug-in
+## Uninstalling
 
 **Follow these steps:**
 
@@ -132,16 +142,14 @@ Any failures potentially indicate an issue with the set-up of the Rest API or co
     
 After the uninstallation process completes successfully, the product no longer contains the plug-in.
 
-## Tutorials
+## Contributing
 
-To learn about how to work with the sample plug-in, build new commands, or build a new plug-in for Zowe CLI, see [Develop for Zowe CLI](https://zowe.github.io/docs-site/latest/extend/extend-cli/cli-devTutorials.html).
+For information about contributing to the plug-in, see the Zowe CLI [Contribution Guidelines](CONTRIBUTING.md). The guidelines contain standards and conventions for developing plug-ins for Zowe CLI. This includes information about running, writing, maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates properly with Zowe CLI.
 
-## Imperative CLI Framework documentation
+### Tutorials
+
+To learn about building new commands or a new plug-in for Zowe CLI, see [Develop for Zowe CLI](https://zowe.github.io/docs-site/latest/extend/extend-cli/cli-devTutorials.html).
+
+### Imperative CLI Framework documentation
 
 [Imperative CLI Framework](https://github.com/zowe/imperative/wiki) documentation is a key source of information to learn about the features of Imperative CLI Framework (the code framework that you use to build plug-ins for Zowe CLI). Refer to the documentation as you develop your plug-in.
-
-## Contributing to the plug-in
-
-For information about contributing to the plug-in, see the Zowe CLI [Contribution Guidelines](CONTRIBUTING.md). The guidelines contain standards and conventions for developing plug-ins for Zowe CLI.
-
-The guidelines contain critical information about working with the code. This includes information about, running, writing, maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates properly with Zowe CLI.

--- a/README.md
+++ b/README.md
@@ -70,24 +70,16 @@ Use one of the following methods to install the plug-in:
     zowe plugins install .
     ```
 
-## (Optional) Validating the plug-in
+**Tip:** After the installation process completes, it validates that the plug-in was installed correct and the names of its commands, options, and arguments do not conflict with that of the other plug-ins that you installed into your Zowe CLi implimentation.
 
-The validation process helps to ensure the following conditions:
--   The installation process completed successfully.
--   The plug-in does ***not*** contain commands, options, and arguments that conflict (possess the same names) with other plug-ins that are installed in your Zowe CLI installation.
+When the validation process is successful, the following messaage displays:
 
-**Follow these steps:**
+```
+Validation results for plugin 'mq':
+Successfully validated.
+```
 
-1. Issue the following command:
-    ```
-    zowe plugins validate @zowe/mq-for-zowe-cli
-    ```
-    When you install the plug-in successfully, the following message displays:
-    ```
-    Validation results for plugin 'mq':
-    Successfully validated.
-    ``` 
-    **Tip:** When an unsuccessful message displays, you can troubleshoot the installation by addressing the issues that the message describes. You can also review the information that is contained in the log file that is located in the directory where you installed Zowe CLI.  
+When an unsuccessful message displays, you can troubleshoot the installation by addressing the issues that the message describes. You can also review the information that is contained in the log file that is located in the directory where you installed Zowe CLI.
 
 ## Creating a user profile
 You can create an `mq` user profile to avoid typing your connection details on every command. An `mq` profile contains the host, port, username, and password for the MQ Rest API server of your choice. You can create multiple profiles and switch between them as needed.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Before you install the plug-in, complete the following prerequisites:
 
 -   Ensure that [IBM® MQ™ v9.1.0](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.sce.doc/q121910_.htm) or later is installed and running in your mainframe environment.
 
--   Zowe installation with MQ. For more insformation, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/).
+-   Zowe installation with MQ. For more information, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/).
 
 ## Installing the plug-in
 
@@ -27,11 +27,15 @@ Use one of the following methods to install the plug-in:
 
 -   Install the plug-in from an online registry or a local package.
 
-    Use the online registry/local package method when you simply want to install the plug-in to Zowe CLI and start using it. For more information, see [Installing plug-ins](https://zowe.github.io/docs-site/latest/user-guide/cli-installplugins.html) on the [Zowe Docs](https://zowe.github.io/docs-site/latest/) website.
+    Use the online registry/local package method when you simply want to install the plug-in to Zowe CLI and start using it.
+    
+    For more information, see [Installing plug-ins](https://zowe.github.io/docs-site/latest/user-guide/cli-installplugins.html) on the [Zowe Docs](https://zowe.github.io/docs-site/latest/) website.
 
 -   Build the plug-in from source and install it into your Zowe CLI implementation.
 
-    Use the build from source method when you want to install tha plug-in to Zowe CLI using the most current binaries and modify the behavior of the plug-in. For example, you want to create a new command and use the plug-in with the command that you created. For more information, see [Building the plug-in from source](#building-the-plug-in-from-source).
+    Use the build from source method when you want to install the plug-in to Zowe CLI using the most current binaries and modify the behavior of the plug-in. For example, you want to create a new command and use the plug-in with the command that you created.
+    
+    For more information, see [Building the plug-in from source](#building-the-plug-in-from-source).
 
 ## Building the plug-in from source
 
@@ -66,11 +70,11 @@ Use one of the following methods to install the plug-in:
     zowe plugins install .
     ```
 
-## (Optional) Validate the plug-in
+## (Optional) Validating the plug-in
 
 The validation process helps to ensure the following conditions:
 -   The installation process completed successfully.
--   The plug-in does ***not*** contain commands, options, and arguement that conflict (possess the same names) as the other plug-ins that are installed in your Zowe CLI installation.
+-   The plug-in does ***not*** contain commands, options, and arguments that conflict (possess the same names) as the other plug-ins that are installed in your Zowe CLI installation.
 
 **Follow these steps:**
 
@@ -85,7 +89,7 @@ The validation process helps to ensure the following conditions:
     ``` 
     **Tip:** When an unsuccessful message displays, you can troubleshoot the installation by addressing the issues that the message describes. You can also review the information that is contained in the log file that is located in the directory where you installed Zowe CLI.  
 
-## Create a User Profile
+## Creating a user profile
 You can create an `mq` user profile to avoid typing your connection details on every command. An `mq` profile contains the host, port, username, and password for the MQ Rest API server of your choice. You can create multiple profiles and switch between them as needed.
 
 **Follow these steps:**
@@ -102,16 +106,16 @@ You can create an `mq` user profile to avoid typing your connection details on e
 zowe profiles create mq-profile -h
 ```
 
-## Run Tests
+## Running tests
 
-You can perform the follwing types of tests:
-- unit
-- integration
-- system
+You can perform the following types of tests on the plug-in:
+- Unit
+- Integration
+- System
 
 Before running the system and integration tests, you must have a server connection to run against. For more information, see [Prerequisites](#prerequisites).
 
-To define  access credentials to the server, copy the  file named `.../__tests__/__resources__/properties/example_properties.yaml` and create a file named `.../__tests__/__resources__/properties/custom_properties.yaml`.
+To define access credentials to the server, copy the file named `.../__tests__/__resources__/properties/example_properties.yaml` and create a file named `.../__tests__/__resources__/properties/custom_properties.yaml`.
 
 **Note:** Information about how to customize the `custom_properties.yaml` file is provided in the yaml file itself.
 
@@ -122,7 +126,7 @@ Issue the following commands to run the tests:
 
 Any failures potentially indicate an issue with the set-up of the Rest API or configuration parameters that were passed in the `custom_properties.yaml` file.
 
-## Uninstall the plug-in
+## Uninstalling the plug-in
 
 **Follow these steps:**
 
@@ -138,7 +142,7 @@ After the uninstallation process completes successfully, the product no longer c
 
 To learn about how to work with this sample plug-in, build new commands, or build a new plug-in for Zowe CLI, see [Develop for Zowe CLI](https://zowe.github.io/docs-site/latest/extend/extend-cli/cli-devTutorials.html).
 
-## Imperative CLI Framework Documentation
+## Imperative CLI Framework documentation
 
 [Imperative CLI Framework](https://github.com/zowe/imperative/wiki) documentation is a key source of information to learn about the features of Imperative CLI Framework (the code framework that you use to build plug-ins for Zowe CLI). Refer to the documentation as you develop your plug-in.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ After the uninstallation process completes successfully, the product no longer c
 
 ## Tutorials
 
-To learn about how to work with this sample plug-in, build new commands, or build a new plug-in for Zowe CLI, see [Develop for Zowe CLI](https://zowe.github.io/docs-site/latest/extend/extend-cli/cli-devTutorials.html).
+To learn about how to work with the sample plug-in, build new commands, or build a new plug-in for Zowe CLI, see [Develop for Zowe CLI](https://zowe.github.io/docs-site/latest/extend/extend-cli/cli-devTutorials.html).
 
 ## Imperative CLI Framework documentation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IBM MQ Plug-in for Zowe CLI
+# IBM® MQ Plug-in for Zowe CLI
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli-ims-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli-mq-plugin)
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,24 @@
 
 [![codecov](https://codecov.io/gh/zowe/zowe-cli-ims-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/zowe/zowe-cli-mq-plugin)
 
-The IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. MQSC commands let you perform administration tasks, such as defining, altering, and deleting local queue objects. For more infornation MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
-
-## Contributing to the plug-in 
-For information about contributing to the plug-in, see the Zowe CLI [contribution guidelines](CONTRIBUTING.md), which contains standards and conventions for developing plug-ins for Zowe CLI.
-
-The guidelines contain critical information about working with the code, running, writing, maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates properly with Zowe CLI.
+The IBM MQ Plug-in for Zowe CLI lets you issue MQSC commands to a queue manager. With MQSC commands you can perform administration tasks, such as defining, altering, and deleting local queue objects. For more infornation MQSC commands and syntax, see [MQSC commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q085130_.htm).
 
 ## Prerequisites
+
 Before you install the plug-in, complete the following prerequisites:
 -   Install Zowe CLI on your computer.
 
     **Note:** For more information, see [Installing Zowe CLI](https://zowe.github.io/docs-site/latest/user-guide/cli-installcli.html).
 
-* Ensure that [IBM® MQ™ v9.1.0](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.sce.doc/q121910_.htm) or later is installed and running in your mainframe environment.
+-   Ensure that [IBM® MQ™ v9.1.0](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.sce.doc/q121910_.htm) or later is installed and running in your mainframe environment.
 
-* Zowe installation with MQ. For more insformation, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/)
+-   Zowe installation with MQ. For more insformation, see [Exposing the MQ REST API via the Zowe API Mediation Layer](https://developer.ibm.com/messaging/2019/05/17/exposing-the-mq-rest-api-via-the-zowe-api-mediation-layer/)
 
 ## Understanding how the plug-in works
-- The plug-in defines an MQ profile to manage the connection information that is required to access the MQ API.
-- It implements a local API to interface with the relevant API on the server.
-- The plug-in creates a wrapping CLI around the local API to provide the command line function.
+
+-   The plug-in defines an MQ profile to manage the connection information that is required to access the MQ API.
+-   It implements a local API to interface with the relevant API on the server.
+-   The plug-in creates a wrapping CLI around the local API to provide the command line function.
 
 ## Installing the plug-in
 
@@ -39,14 +36,15 @@ Use one of the following methods to install the plug-in:
 ## Building the plug-in from source
 
 **Follow these steps:**
-1. The first time that you clone the IBM MQ Plug-in for Zowe CLI from the GitHub repository, issue the following command against the local directory:
+
+1.  The first time that you clone the IBM MQ Plug-in for Zowe CLI from the GitHub repository, issue the following command against the local directory:
 
     ```
     npm install
     ```
     The command installs the required IBM MQ Plug-in for Zowe CLI dependencies and several development tools. When necessary, you can run the task at any time to update the tools.
 
-2. To build your code changes, issue the following command:
+2.  To build your code changes, issue the following command:
 
     ```
     npm run build
@@ -56,7 +54,7 @@ Use one of the following methods to install the plug-in:
 
     **Note:** When you update `package.json` to include new dependencies, or when you pull changes that affect `package.json`, issue the `npm update` command to download the dependencies.
 
-3. Issue one of the following commands to install the plug-in:
+3.  Issue one of the following commands to install the plug-in:
 
     ```
     zowe plugins install <local path your cloned repo>
@@ -68,13 +66,11 @@ Use one of the following methods to install the plug-in:
     zowe plugins install .
     ```
 
-## Validate the plug-in
+## (Optional) Validate the plug-in
 
 The validation process helps to ensure the following conditions:
-The installation process completed successfully.
-The plug-in does ***not*** contain commands, options, and arguement that conflict (possess the same names) as the other plug-ins that are installed in your Zowe CLI installation.
-
-**Note:** This is an optional task.
+-   The installation process completed successfully.
+-   The plug-in does ***not*** contain commands, options, and arguement that conflict (possess the same names) as the other plug-ins that are installed in your Zowe CLI installation.
 
 **Follow these steps:**
 
@@ -93,11 +89,12 @@ The plug-in does ***not*** contain commands, options, and arguement that conflic
 You can create an `mq` user profile to avoid typing your connection details on every command. An `mq` profile contains the host, port, username, and password for the MQ Rest API server of your choice. You can create multiple profiles and switch between them as needed.
 
 **Follow these steps:**
+
 1.  Create an `mq` profile: 
     ```
     zowe profiles create mq-profile <profileName> --host <hostname> --port <portnumber> --user <username> --password <password> --rejectUnauthorized false
     ```
-    The result of the command displays as a success or failure message. You can use your profile when you issue commands in the mq command group.
+    The result of the command displays as a success or failure message. You can use the profile when you issue commands in the mq command group.
 
 **Tip:** For more information about the syntax, actions, and options, for a profiles create command, open Zowe CLI and issue the following command:
 
@@ -112,17 +109,18 @@ The IBM MQ Plug-in for Zowe CLI uses the following tests:
 - integration
 - system
 
-Before running the integration and system tests it is necessary to have a server connection to run against as described in the [Prerequisites](#prerequisites) section.
+Before running the system and integration tests, you must have a server connection to run against. For more information, see [Prerequisites](#prerequisites).
 
-Access credentials to this server is defined by copying the __tests__/__resources__/properties/example_properties.yaml file to create a new file __tests__/__resources__/properties/custom_properties.yaml
-Instructions of how to update your new custom_properties.yaml are provided in the file itself.
+To define  access credentials to the server, copy the file named `__tests__/__resources__/properties/example_properties.yaml` and create a file named `__tests__/__resources__/properties/custom_properties.yaml`.
 
- To run the unit tests simply type in the following:
+**Note:** Information about how to customize the `custom_properties.yaml` file is provided in the yaml file itself.
+
+Issue the following commands to run the tests:
 1. `npm run test:unit`
 2. `npm run test:integration`
 3. `npm run test:system`
 
-Any failures potentially indicate an issue with the set-up of the Rest API or configuration parameters passed in the custom_properties.yaml file
+Any failures potentially indicate an issue with the set-up of the Rest API or configuration parameters that were passed in the `custom_properties.yaml` file.
 
 ## Uninstall the plug-in
 
@@ -136,10 +134,16 @@ Any failures potentially indicate an issue with the set-up of the Rest API or co
 After the uninstallation process completes successfully, the product no longer contains the plug-in. 
 
 
-### Tutorials
+## Tutorials
 
 To learn about how to work with this sample plug-in, build new commands, or build a new plug-in for Zowe CLI, see [Develop for Zowe CLI](https://zowe.github.io/docs-site/latest/extend/extend-cli/cli-devTutorials.html).
 
-### Imperative CLI Framework Documentation
+## Imperative CLI Framework Documentation
 
 [Imperative CLI Framework](https://github.com/zowe/imperative/wiki) documentation is a key source of information to learn about the features of Imperative CLI Framework (the code framework that you use to build plug-ins for Zowe CLI). Refer to the documentation as you develop your plug-in.
+
+## Contributing to the plug-in
+
+For information about contributing to the plug-in, see the Zowe CLI [contribution guidelines](CONTRIBUTING.md). The guidelines contain standards and conventions for developing plug-ins for Zowe CLI.
+
+The guidelines contain critical information about working with the code, running, writing, maintaining automated tests, developing consistent syntax in your plug-in, and ensuring that your plug-in integrates properly with Zowe CLI.

--- a/README.md
+++ b/README.md
@@ -108,10 +108,12 @@ zowe profiles create mq-profile -h
 
 ## Running tests
 
-You can perform the following types of tests on the plug-in:
+You can perform the following types of tests on the IBM MQ plug-in:
 - Unit
 - Integration
 - System
+
+**Note:** For detailed information about conventions and best practices for running tests against Zowe CLI plug-ins, see see [Zowe CLI Plug-in Testing Guidelines](https://github.com/zowe/zowe-cli/blob/master/docs/PluginTESTINGGuidelines.md).
 
 Before running the system and integration tests, you must have a server connection to run against. For more information, see [Prerequisites](#prerequisites).
 


### PR DESCRIPTION
Made the following changes to the README file:
- See see > see
- typo on implementation
- fixed broken link to Building from source