### PR TITLE
Remove CPI Peer Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® MQ Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Remove @zowe/cli peer dependency to better support NPM v7
+
 ## `2.0.1`
 
 - Fix plugin install warnings

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "configurationModule": "lib/imperative.js"
   },
   "peerDependencies": {
-    "@zowe/cli": "7.0.0-next.202103152050",
     "@zowe/imperative": "5.0.0-next.202104071400"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove @zowe/cli peer dependency to better support NPM v7

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>