### PR TITLE
Apiml conn lookup next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® MQ Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Add apimlConnLookup properties to enable auto-config through APIML. A valid apiId must still be identified.
+
 ## `3.0.0-next.202104261401`
 
 - Remove @zowe/cli peer dependency to better support NPM v7

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node('zowe-jenkins-agent') {
     // Protected branch property definitions
     pipeline.protectedBranches.addMap([
         [name: "master", tag: "latest", devDependencies: ["@zowe/imperative": "zowe-v1-lts"], aliasTags: ["zowe-v1-lts"], autoDeploy: true],
-        [name: "next", tag: "next", prerelease: "next", devDependencies: ["@zowe/imperative": "next"], autoDeploy: true]
+        [name: "next", tag: "next", prerelease: "next", autoDeploy: true]
         //[name: "master", tag: "latest", devDependencies: ["@zowe/imperative": "latest"], autoDeploy: true],
         //[name: "zowe-v1-lts", tag: "zowe-v1-lts", devDependencies: ["@zowe/imperative": "zowe-v1-lts"], autoDeploy: true]
     ])

--- a/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/__tests__/__snapshots__/imperative.test.ts.snap
@@ -2,6 +2,13 @@
 
 exports[`imperative config should match the snapshot 1`] = `
 Object {
+  "apimlConnLookup": Array [
+    Object {
+      "apiId": "place_the_mq_apiId_here",
+      "connProfType": "mq",
+      "gatewayUrl": "api/v1",
+    },
+  ],
   "commandModuleGlobs": Array [
     "**/cli/*/*.definition!(.d).*s",
   ],

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "configurationModule": "lib/imperative.js"
   },
   "peerDependencies": {
-    "@zowe/imperative": "5.0.0-next.202104071400"
+    "@zowe/imperative": ">=5.0.0-next.202106221817 <5.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.16",
@@ -45,7 +45,7 @@
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.10.66",
     "@types/yargs": "^11.1.7",
-    "@zowe/imperative": "^5.0.0-next.202104142114",
+    "@zowe/imperative": ">=5.0.0-next <6.0.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "jest-cli": "^26.6.3",
     "jest-environment-node": "^26.6.2",
     "jest-environment-node-debug": "^2.0.0",
-    "jest-html-reporter": "^2.8.2",
+    "jest-html-reporter": "^3.4.1",
     "jest-junit": "^6.4.0",
     "jest-sonar-reporter": "^2.0.0",
     "jest-stare": "^1.13.2",

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -19,6 +19,13 @@ const config: IImperativeConfig = {
     productDisplayName: PluginConstants.PLUGIN_NAME,
     name: PluginConstants.PLUGIN_GROUP_NAME,
     pluginHealthCheck: __dirname + "/healthCheck.Handler",
+    apimlConnLookup: [
+        {
+          apiId: "place_the_mq_apiId_here",
+          gatewayUrl: "api/v1",
+          connProfType: "mq"
+        }
+    ],
     profiles: [
         {
           type: "mq",


### PR DESCRIPTION
Add apimlConnLookup properties to enable auto-config through APIML.
A valid apiId for MQ must still be identified.