### PR TITLE
Update packages to suppport Node 24

### DIFF
--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         os:
           - windows-latest
           - ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® MQ Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated minimum supported version of Node from 18 to 20. Added Node 24 support. []()
+
 ## `4.0.0`
 
 - MAJOR: v4.0.0 release

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "license": "EPL-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.12",
-        "@types/node": "^18.19.17",
+        "@types/node": "^24.0.0",
         "@types/yargs": "^17.0.32",
         "@typescript-eslint/eslint-plugin": "^7.1.0",
         "@typescript-eslint/parser": "^7.1.0",
@@ -29,7 +29,7 @@
         "jest-html-reporter": "^3.10.2",
         "jest-junit": "^16.0.0",
         "jest-sonar-reporter": "^2.0.0",
-        "jest-stare": "^2.5.1",
+        "jest-stare": "^2.5.3",
         "madge": "^6.1.0",
         "rimraf": "^5.0.0",
         "ts-jest": "^29.1.2",
@@ -38,7 +38,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
         "@zowe/imperative": "^8.0.0"
@@ -1980,13 +1980,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.87",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
-      "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+      "version": "24.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.1.tgz",
+      "integrity": "sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.13.0"
       }
     },
     "node_modules/@types/semver": {
@@ -6541,9 +6541,9 @@
       }
     },
     "node_modules/jest-stare": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jest-stare/-/jest-stare-2.5.2.tgz",
-      "integrity": "sha512-dvxHXOsiJlvBi0n2dK9pz6RWFTdPB6njc2ZoMpyjmWI+aIL+X1W8OW5mTm1pkv/quy2ocKO/G+GsTe7Bv07xkQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/jest-stare/-/jest-stare-2.5.3.tgz",
+      "integrity": "sha512-HXykqTNNxguOQZiWCEcUPC5HleaVngQysyyniG6LzoeBsM4dtq4YDw/JruS2ChfRBS/9PUcG04eAx6NdcbFDDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10104,9 +10104,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/node": "^18.19.17",
+    "@types/node": "^24.0.0",
     "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
@@ -59,7 +59,7 @@
     "jest-html-reporter": "^3.10.2",
     "jest-junit": "^16.0.0",
     "jest-sonar-reporter": "^2.0.0",
-    "jest-stare": "^2.5.1",
+    "jest-stare": "^2.5.3",
     "madge": "^6.1.0",
     "rimraf": "^5.0.0",
     "ts-jest": "^29.1.2",
@@ -142,6 +142,6 @@
   "author": "Zowe",
   "license": "EPL-2.0",
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=20.9.0"
   }
 }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Update packages to support Node 24
Update engine version to support Node >=20
Remove support for Node 18 (which has been out of support for months)
Add Node 24 workflow

Note: As this plug-in works with Node 24 as-is, this can be merged `release-current`.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->