### PR TITLE
refactor: secure default for `reject-unauthorized` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the IBM® MQ Plug-in for Zowe CLI will be documented in t
 
 ## Recent Changes
 
+- Breaking: Changed the default value of the `reject-unauthorized` option to `true` so that TLS certificates presented by the IBM MQ REST API are validated by default, preventing credentials from being sent over an unverified connection. Profiles or commands relying on the previous insecure default must now explicitly pass `--reject-unauthorized false`. [#127](https://github.com/zowe/zowe-cli-mq-plugin/pull/127)
 - BugFix: Updated minimum supported version of Node from 18 to 20. Added Node 24 support. [#91](https://github.com/zowe/zowe-cli-mq-plugin/pull/91)
 
 ## `4.0.0`
@@ -71,4 +72,3 @@ All notable changes to the IBM® MQ Plug-in for Zowe CLI will be documented in t
 ## `1.0.0`
 
 - Initial release
-

--- a/__tests__/__integration__/cli/__snapshots__/cli.mqsc.integration.test.ts.snap
+++ b/__tests__/__integration__/cli/__snapshots__/cli.mqsc.integration.test.ts.snap
@@ -54,7 +54,7 @@ exports[`mq mqsc should display the mqsc help 1`] = `
 
       Reject self-signed certificates.
 
-      Default value: false
+      Default value: true
 
    --protocol (string)
 

--- a/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/__tests__/__snapshots__/imperative.test.ts.snap
@@ -73,7 +73,7 @@ Object {
               "aliases": Array [
                 "ru",
               ],
-              "defaultValue": false,
+              "defaultValue": true,
               "description": "Reject self-signed certificates.",
               "group": "MQ Connection Options",
               "name": "reject-unauthorized",

--- a/__tests__/cli/MQSessionUtils.unit.test.ts
+++ b/__tests__/cli/MQSessionUtils.unit.test.ts
@@ -31,4 +31,9 @@ describe("Tests utils functions not covered elsewhere", () => {
         expect(session.ISession.hostname).toEqual("boppyhost");
         expect(session.ISession.protocol).toEqual("https");
     });
+
+    it("should default reject-unauthorized to true so TLS peers are validated", () => {
+        // Secure default: server certificates are validated unless the operator explicitly opts out.
+        expect(MqSessionUtils.MQ_OPTION_REJECT_UNAUTHORIZED.defaultValue).toBe(true);
+    });
 });

--- a/__tests__/cli/command/__snapshots__/Command.definition.unit.test.ts.snap
+++ b/__tests__/cli/command/__snapshots__/Command.definition.unit.test.ts.snap
@@ -55,7 +55,7 @@ Object {
           "aliases": Array [
             "ru",
           ],
-          "defaultValue": false,
+          "defaultValue": true,
           "description": "Reject self-signed certificates.",
           "group": "MQ Connection Options",
           "name": "reject-unauthorized",

--- a/src/cli/MQSessionUtils.ts
+++ b/src/cli/MQSessionUtils.ts
@@ -84,7 +84,7 @@ export class MqSessionUtils {
         aliases: ["ru"],
         description: "Reject self-signed certificates.",
         type: "boolean",
-        defaultValue: false,
+        defaultValue: true,
         group: MqSessionUtils.MQ_CONNECTION_OPTION_GROUP
     };
     /**


### PR DESCRIPTION
**What It Does**

Establishes a secure default for the `rejectUnauthorized` option (`true`)

**How to Test**

- `zowe mq mqsc run --help` shows updated defaults:
  - `--reject-unauthorized` shows `Default value: true`
- When testing an `mq` profile, the new default should apply to that profile when the property is not overridden in team config: 
  - Against an MQ endpoint with a self-signed/untrusted cert, run any command with no `--ru` flags, e.g.:
`zowe mq mqsc run <queue-manager> "DISPLAY QMGR"`
  - ✅ Expect: connection fails with a certificate/TLS validation error (previously it would have silently succeeded).
- Explicit opt-out should still work for reject-unauthorized (dev environments):
  - `zowe mq mqsc run <queue-manager> "DISPLAY QMGR" --reject-unauthorized false`
  - ✅ Expect: connection succeeds against the same self-signed endpoint

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)