### PR TITLE
refactor(v2): secure defaults for protocol, reject-unauthorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the IBM® MQ Plug-in for Zowe CLI will be documented in t
 
 ## Recent Changes
 
+- BREAKING: Changed the default value of the `--reject-unauthorized` (`--ru`) option from `false` to `true`, so server certificates are validated by default. Connections to endpoints with self-signed or otherwise untrusted certificates now fail unless you explicitly opt out with `--reject-unauthorized false`. [#128](https://github.com/zowe/zowe-cli-mq-plugin/pull/128)
+- BREAKING: Changed the default value of the `--protocol` option from `http` to `https`, so connections are encrypted by default. Endpoints that only serve plaintext HTTP now require you to explicitly set `--protocol http`. [#128](https://github.com/zowe/zowe-cli-mq-plugin/pull/128)
 - BugFix: Add missing npm-shrinkwrap
 
 ## `3.0.1`
@@ -58,4 +60,3 @@ All notable changes to the IBM® MQ Plug-in for Zowe CLI will be documented in t
 ## `1.0.0`
 
 - Initial release
-

--- a/__tests__/__integration__/cli/__snapshots__/cli.mqsc.integration.test.ts.snap
+++ b/__tests__/__integration__/cli/__snapshots__/cli.mqsc.integration.test.ts.snap
@@ -54,13 +54,13 @@ exports[`mq mqsc should display the mqsc help 1`] = `
 
       Reject self-signed certificates.
 
-      Default value: false
+      Default value: true
 
    --protocol (string)
 
       Specifies the MQ protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/__tests__/__snapshots__/imperative.test.ts.snap
@@ -65,7 +65,7 @@ Object {
                   "https",
                 ],
               },
-              "defaultValue": "http",
+              "defaultValue": "https",
               "description": "Specifies the MQ protocol (http or https).",
               "group": "MQ Connection Options",
               "name": "protocol",
@@ -78,7 +78,7 @@ Object {
               "aliases": Array [
                 "ru",
               ],
-              "defaultValue": false,
+              "defaultValue": true,
               "description": "Reject self-signed certificates.",
               "group": "MQ Connection Options",
               "name": "reject-unauthorized",

--- a/__tests__/cli/MQSessionUtils.unit.test.ts
+++ b/__tests__/cli/MQSessionUtils.unit.test.ts
@@ -31,4 +31,45 @@ describe("Tests utils functions not covered elsewhere", () => {
         expect(session.ISession.hostname).toEqual("boppyhost");
         expect(session.ISession.protocol).toEqual("https");
     });
+
+    it("should default reject-unauthorized to true so certificate validation is on by default", () => {
+        expect(MqSessionUtils.MQ_OPTION_REJECT_UNAUTHORIZED.defaultValue).toBe(true);
+    });
+
+    it("should default protocol to https so connections are encrypted by default", () => {
+        expect(MqSessionUtils.MQ_OPTION_PROTOCOL.defaultValue).toBe("https");
+    });
+
+    it("should create a session that validates certificates over https using the secure defaults", async () => {
+        const args: ICommandArguments = {
+            $0: "",
+            _: [],
+            host: "boppyhost",
+            port: "port",
+            user: "auser",
+            password: "apassword",
+            basePath: "abasePath",
+            protocol: MqSessionUtils.MQ_OPTION_PROTOCOL.defaultValue,
+            rejectUnauthorized: MqSessionUtils.MQ_OPTION_REJECT_UNAUTHORIZED.defaultValue
+        };
+        const session: Session = await MqSessionUtils.createSessCfgFromArgs(args, false);
+        expect(session.ISession.protocol).toEqual("https");
+        expect(session.ISession.rejectUnauthorized).toBe(true);
+    });
+
+    it("should honor an explicit opt-out of certificate validation for self-signed dev environments", async () => {
+        const args: ICommandArguments = {
+            $0: "",
+            _: [],
+            host: "boppyhost",
+            port: "port",
+            user: "auser",
+            password: "apassword",
+            basePath: "abasePath",
+            protocol: "https",
+            rejectUnauthorized: false
+        };
+        const session: Session = await MqSessionUtils.createSessCfgFromArgs(args, false);
+        expect(session.ISession.rejectUnauthorized).toBe(false);
+    });
 });

--- a/__tests__/cli/command/__snapshots__/Command.definition.unit.test.ts.snap
+++ b/__tests__/cli/command/__snapshots__/Command.definition.unit.test.ts.snap
@@ -55,7 +55,7 @@ Object {
           "aliases": Array [
             "ru",
           ],
-          "defaultValue": false,
+          "defaultValue": true,
           "description": "Reject self-signed certificates.",
           "group": "MQ Connection Options",
           "name": "reject-unauthorized",
@@ -69,7 +69,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies the MQ protocol (http or https).",
           "group": "MQ Connection Options",
           "name": "protocol",

--- a/src/cli/MQSessionUtils.ts
+++ b/src/cli/MQSessionUtils.ts
@@ -84,7 +84,7 @@ export class MqSessionUtils {
         aliases: ["ru"],
         description: "Reject self-signed certificates.",
         type: "boolean",
-        defaultValue: false,
+        defaultValue: true,
         group: MqSessionUtils.MQ_CONNECTION_OPTION_GROUP
     };
     /**
@@ -94,7 +94,7 @@ export class MqSessionUtils {
         name: "protocol",
         description: "Specifies the MQ protocol (http or https).",
         type: "string",
-        defaultValue: "http",
+        defaultValue: "https",
         allowableValues: { values: ["http", "https"], caseSensitive: false },
         group: MqSessionUtils.MQ_CONNECTION_OPTION_GROUP
     };


### PR DESCRIPTION
**What It Does**

Establishes secure defaults for the `protocol` and `rejectUnauthorized` options:

| Option | Old Default | New Default |
| ------- | ------------- | -------------- |
| `protocol` | http (unsafe) | https |
| `rejectUnauthorized` | false (unsafe) | true |

**How to Test**

- `zowe mq mqsc run --help` shows updated defaults:
  - `--reject-unauthorized` shows `Default value: true`
  - `--protocol` shows `Default value: https`
- When testing an `mq` profile, the new defaults should apply to that profile when the properties are not overridden in team config: 
  - Against an MQ endpoint with a self-signed/untrusted cert, run any command with no --ru / --protocol flags, e.g.:
`zowe mq mqsc run <queue-manager> "DISPLAY QMGR"`
  - ✅ Expect: connection fails with a certificate/TLS validation error (previously it would have silently succeeded).
- Explicit opt-out should still work for both options (dev environments):
  - `zowe mq mqsc run <queue-manager> "DISPLAY QMGR" --protocol https --reject-unauthorized false`
  - ✅ Expect: connection succeeds against the same self-signed endpoint
- Point at an HTTPS endpoint with a valid cert and omit `--protocol`:
  - `zowe mq mqsc run <queue-manager> "DISPLAY QMGR"`
  - ✅ Expect: succeeds over HTTPS. Confirms it no longer defaults to plaintext http.
- Create a profile without specifying `protocol`/`ru`, then run a command using it:
  - `zowe profiles create mq-profile <name> --host <h> --port <p> --user <u> --password <pw>`
  - ✅ Expect: same validated-HTTPS-by-default behavior as steps 2–4.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)